### PR TITLE
Do not include root folder when compress it (zip) .

### DIFF
--- a/uncompress-resources.sh
+++ b/uncompress-resources.sh
@@ -36,7 +36,7 @@ compress_with_tar()
 
 compress_with_zip()
 {
-    zip -n resources.arsc -qr "$dst" "$unzipped"
+    (cd $unzipped && zip -n resources.arsc -qr "$OLDPWD/$dst" .)
 }
 
 


### PR DESCRIPTION
Otherwise, it breaks the packaged apk file.
https://unix.stackexchange.com/questions/385405/zip-all-files-and-subfolder-in-directory-without-parent-directory