### PR TITLE
Fix Linux compression by setting compression level to 0

### DIFF
--- a/uncompress-resources.sh
+++ b/uncompress-resources.sh
@@ -36,7 +36,7 @@ compress_with_tar()
 
 compress_with_zip()
 {
-    zip -n resources.arsc -qr "$dst" "$unzipped"
+    (cd $unzipped && zip -n resources.arsc -0 -qr "$OLDPWD/$dst" .)
 }
 
 


### PR DESCRIPTION
I wasn't able to generate correct APKs, each APK was about half the correct size and was invalid. I fixed this by setting the zip compression level to 0 by adding the option `-0` in `compress_with_zip()`, and also combining https://github.com/mathieures/convert-apk/pull/4 into this PR.